### PR TITLE
Rs/core population

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ __pycache__
 .cache/
 .pytest_cache/
 
-*.ipynb
+*.ipynb.direnv
+
+.direnv
+.envrc

--- a/pam/core.py
+++ b/pam/core.py
@@ -34,20 +34,22 @@ class Population:
 
             for pid, person_data in household_data.groupby('pid'):
 
-                # todo deal with agents not starting from home
+                # TODO deal with agents not starting from home
                 # tests/test_load.py::test_agent_pid_5_not_start_from_home
 
                 trips = person_data.sort_values('seq')
                 home_area = trips.hzone.iloc[0]
+                origin_area = trips.ozone.iloc[0]
                 activity_map = {home_area: 'home'}
-                activities = ['home']
+                activities = ['home', 'work']
 
                 person = Person(int(pid), freq=person_data.freq.iloc[0])
+
                 person.add(
                     Activity(
                         seq=0,
-                        act='home',
-                        area=home_area,
+                        act='home' if home_area == origin_area else 'work',
+                        area=origin_area,
                         start_time=minutes_to_datetime(0),
                     )
                 )


### PR DESCRIPTION
This doesn't fix all the tests (agents 12 and 13 hard) but does pass the rest. There's probably some assumptions I'm making or breaking by doing it this way but thought it was at least sharing what I did.

- Adding 'work' hardcoded to `activities` seems ok to me at the moment as there is an assumption 'work' is always one of the diary entries purposes
- Similarly the assumption that `'home' if home_area == origin_area else 'work'` seems pretty limited but an improvement of _just_ assuming 'home' and I don't think there are any other options for where an agent can start at the moment?

For either of the above values I'm not sure if extracting them from the dataset would be preferable (and somehow make it more dynamic? How much control is there expected be over the input diaries longer term?)

```
tests/test_1_core.py::test_minutes_to_dt[0-expected0] PASSED
tests/test_1_core.py::test_minutes_to_dt[30-expected1] PASSED
tests/test_1_core.py::test_minutes_to_dt[300-expected2] PASSED
tests/test_1_core.py::test_minutes_to_dt[330-expected3] PASSED
tests/test_1_core.py::test_load PASSED
tests/test_1_core.py::test_agent_pid_0_simple_tour PASSED
tests/test_1_core.py::test_agent_pid_1_simple_tour PASSED
tests/test_1_core.py::test_agent_pid_2_simple_tour PASSED
tests/test_1_core.py::test_agent_pid_3_tour PASSED
tests/test_1_core.py::test_agent_pid_4_complex_tour PASSED
tests/test_2_core_challenge.py::test_agent_pid_5_not_start_from_home PASSED
tests/test_2_core_challenge.py::test_agent_pid_6_not_return_home PASSED
tests/test_2_core_challenge.py::test_agent_pid_7_not_start_and_return_home_night_worker PASSED
tests/test_2_core_challenge.py::test_agent_pid_8_not_start_and_return_home_night_worker_complex_chain_type1 PASSED
tests/test_2_core_challenge.py::test_agent_pid_9_not_start_and_return_home_night_worker_complex_chain_type2 PASSED
tests/test_2_core_challenge.py::test_agent_pid_10_not_start_from_home_impossible_chain_type1 PASSED
tests/test_2_core_challenge.py::test_agent_pid_11_not_start_from_home_impossible_chain_type2 PASSED
tests/test_2_core_challenge.py::test_agent_pid_12_not_start_and_return_home_night_worker_complex_chain_type1_intra_trip FAILED
tests/test_2_core_challenge.py::test_agent_pid_13_not_start_and_return_home_night_worker_complex_chain_type2_intra_trip FAILED
tests/test_2_core_challenge.py::test_agent_pid_14_not_start_from_home_impossible_chain_type1_intra_trip PASSED
tests/test_2_core_challenge.py::test_agent_pid_15_not_start_from_home_impossible_chain_type2_intra_trip PASSED
tests/test_3_household_policies.py::test_apply_full_hh_quarantine PASSED
tests/test_3_household_policies.py::test_apply_full_person_stay_at_home PASSED
tests/test_3_household_policies.py::test_apply_two_policies PASSED
tests/test_4_activity_policies.py::test_home_education_home_removal_of_education_act PASSED
tests/test_4_activity_policies.py::test_home_education_home_education_home_removal_of_education_act PASSED
tests/test_4_activity_policies.py::test_home_work_home_education_home_removal_of_education_act PASSED
```